### PR TITLE
Fix Home page auth state and mock router for tests

### DIFF
--- a/web-client/src/App.test.js
+++ b/web-client/src/App.test.js
@@ -1,8 +1,36 @@
+import React from 'react';
 import { render, screen } from '@testing-library/react';
+
+// Mock react-router-dom to avoid loading the actual library which is ESM only
+jest.mock(
+  'react-router-dom',
+  () => ({
+    BrowserRouter: ({ children }) => <div>{children}</div>,
+    Routes: ({ children }) => <div>{children}</div>,
+    Route: ({ element }) => element,
+    Navigate: () => null,
+    useLocation: () => ({ pathname: '/', state: null }),
+    useNavigate: () => () => {},
+    useParams: () => ({}),
+  }),
+  { virtual: true }
+);
+
+// Mock global fetch used in Home component
+beforeEach(() => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({ json: () => Promise.resolve({ data: [] }) })
+  );
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders home page heading', async () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = await screen.findByText(/ร้านยา:/i);
+  expect(heading).toBeInTheDocument();
 });

--- a/web-client/src/js/pages/default/home.js
+++ b/web-client/src/js/pages/default/home.js
@@ -25,7 +25,7 @@ function PharmacyItem({ id, name_th, address, time_open, time_close, phone_store
   );
 }
 
-function Home() {
+function Home({ isLoggedIn, onLogout }) {
   const [pharmacies, setPharmacies] = useState([]);
   const [loading, setLoading] = useState(true);
   const [searchText, setSearchText] = useState('');
@@ -46,7 +46,7 @@ function Home() {
 
   return (
     <div className="app-container">
-      <HomeHeader onSearch={setSearchText} />
+      <HomeHeader onSearch={setSearchText} isLoggedIn={isLoggedIn} onLogout={onLogout} />
       <main className="main-content">
         <h2>ร้านยา:</h2>
         {loading ? (


### PR DESCRIPTION
## Summary
- pass auth state and logout handler from Home to HomeHeader
- mock react-router-dom and fetch in tests to handle ESM modules

## Testing
- `npm test -- --runTestsByPath src/App.test.js`
- `npm test` (web-server, fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_6895b58c6bc8832089ad3ddc7007cfe7